### PR TITLE
When image too small or canceling crop, remove image selection

### DIFF
--- a/js/input-v4.js
+++ b/js/input-v4.js
@@ -50,6 +50,7 @@
 							$field.addClass('invalid');
 							$field.find('.init-crop-button').attr('disabled', 'disabled');
 							alert('Warning: The selected image is smaller than the required size:\n' + warnings.join('\n'));
+							removeImage($field);
 						}
 						else{
 							if($options.data('force-crop')){
@@ -76,6 +77,7 @@
 			$field.find('.cancel-crop-button').click(function(e){
 				e.preventDefault();
 				cancelCrop($field);
+				removeImage($field);
 			});
 			$field.on('click', '.acf-image-uploader .acf-button-edit', function( e ){
 				e.preventDefault();
@@ -222,6 +224,10 @@
                 cancelCrop($field);
 			}, 'json');
 		}
+	}
+
+	function removeImage($field){
+		$field.find('.acf-button-delete.ir').click();
 	}
 
 	function cancelCrop($field){

--- a/js/input.js
+++ b/js/input.js
@@ -264,6 +264,7 @@ function initialize_field( $el ) {
                         $field.find('.init-crop-button').attr('disabled', 'disabled');
 // changed for translation
                         alert(acf._e('image_crop', 'size_warning') + '\n\n' + warnings.join('\n\n'));
+                        removeImage($field);
 // changed END
                     }
                     else{
@@ -291,6 +292,7 @@ function initialize_field( $el ) {
         $field.find('.cancel-crop-button').click(function(e){
             e.preventDefault();
             cancelCrop($field);
+            removeImage($field);
         });
         // $field.find('[data-name=edit]').click(function(e){
         //     e.preventDefault();
@@ -432,6 +434,10 @@ function initialize_field( $el ) {
                 cancelCrop($field);
             }, 'json');
         }
+    }
+
+    function removeImage($field){
+      $field.find('*[data-name="remove"].acf-icon.-cancel').click();
     }
 
     function cancelCrop($field){


### PR DESCRIPTION
If the user cancels the crop then the image is not cropped.  If one or both of the image's dimensions are too small, the crop window does not appear and the image is also not cropped.

If the image is not cropped, the user can still save it, resulting an image of an undesirable ratio being saved.  This change ensures that the image selection is removed if the user cancels the crop or the image is too small.
