### PR TITLE
Add custom filter to allow users to define correct url

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,23 @@ This add-on can be treated as both a WP plugin and a theme include.
 1.	Copy the 'acf-image_crop' folder into your theme folder (can use sub folders). You can place the folder anywhere inside the 'wp-content' directory
 2.	Edit your functions.php file and add the code below (Make sure the path is correct to include the acf-image_crop.php file)
 
-`
-add_action('acf/register_fields', 'my_register_fields');
+```PHP
+/**
+ * Include ACF Image Crop Addon
+ */
 
-function my_register_fields()
-{
-	include_once('acf-image-crop/acf-image-crop.php');
-}
-`
+ add_filter('acf/image_crop_settings/url', 'my_image_crop_url', 10, 1);
+
+ function my_image_crop_url( $url ) {
+   
+   $url = get_template_directory_uri() . '/acf-image-crop/';
+   
+   return $url;
+   
+ }
+
+include( 'acf-image-crop/acf-image-crop.php' );
+```
 
 ## Screenshots ##
 

--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -467,7 +467,7 @@ class acf_field_image_crop extends acf_field_image {
 
 
     function input_admin_enqueue_scripts() {
-        $dir = plugin_dir_url( __FILE__ );
+        $dir = apply_filters( 'acf/image_crop_settings/url', plugin_dir_url( __FILE__ ) );
 
 
         // // register & include JS
@@ -846,7 +846,7 @@ class acf_field_image_crop extends acf_field_image {
 
     function field_group_admin_enqueue_scripts() {
 
-        $dir = plugin_dir_url( __FILE__ );
+        $dir = apply_filters( 'acf/image_crop_settings/url', plugin_dir_url( __FILE__ ) );
 
         wp_register_script('acf-input-image-crop-options', "{$dir}js/options.js", array('jquery'));
         wp_enqueue_script( 'acf-input-image-crop-options');


### PR DESCRIPTION
I noticed that when I tried to include this in a custom theme, it was referencing a wrong url for including the js and css in the backend. I've added a custom filter to allow users to define the correct url for the js and css.

I've tested this change by both including it in a custom theme and using it as a stand-alone plugin and have not noticed any errors.