### PR TITLE
Return target size url if image is not cropped

### DIFF
--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -953,6 +953,12 @@ class acf_field_image_crop extends acf_field_image {
         {
             if(is_numeric($data->cropped_image)){
                 $value = wp_get_attachment_url( $data->cropped_image );
+                if ( $field['target_size'] !== 'custom' ) {
+                    $img = wp_get_attachment_image_src( $data->cropped_image, $field['target_size'] );
+                    if ( is_array( $img ) ) {
+                        $value = $img[0];
+                    }
+                }
             }
             elseif(is_array($data->cropped_image)){
 


### PR DESCRIPTION
If "save media library" option is not enabled and the image is not (yet) cropped, get_field returns full size image url. 

It would be better if get_field returned the target size image url.