### PR TITLE
Added filter to image path on get image editor

### DIFF
--- a/acf-image-crop-v4.php
+++ b/acf-image-crop-v4.php
@@ -763,7 +763,7 @@ class acf_field_image_crop extends acf_field_image
         $originalImageData = wp_get_attachment_metadata($id);
 
         // Get image editor from original image path to crop the image
-        $image = wp_get_image_editor( $mediaDir['basedir'] . '/' . $originalImageData['file'] );
+        $image = wp_get_image_editor( apply_filters( 'acf-image-crop/full_image_path', $mediaDir['basedir'] . '/' . $originalImageData['file'], $id, $originalImageData) );
 
         if(! is_wp_error( $image ) ){
 

--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -520,7 +520,7 @@ class acf_field_image_crop extends acf_field_image {
         $originalImageData = wp_get_attachment_metadata($id);
 
         // Get image editor from original image path to crop the image
-        $image = wp_get_image_editor( $mediaDir['basedir'] . '/' . $originalImageData['file'] );
+        $image = wp_get_image_editor( apply_filters( 'acf-image-crop/full_image_path', $mediaDir['basedir'] . '/' . $originalImageData['file'], $id, $originalImageData) );
 
         // Set quality
         $image->set_quality( apply_filters('acf-image-crop/image-quality', 100) );


### PR DESCRIPTION
Using the filter, others plugin would be able to filter the image path in case image is located elsewhere.
Issue wpCloud/wp-stateless#151