### PR TITLE
Feature/#50 text domain fixes

### DIFF
--- a/acf-image-crop-v4.php
+++ b/acf-image-crop-v4.php
@@ -230,14 +230,14 @@ class acf_field_image_crop extends acf_field_image
 	</td>
 </tr>
 <?php
-	$retina_instructions = __('Require and crop double the size set for this image. Enable this if you are using plugins like WP Retina 2x.','acf-image_crop');
+	$retina_instructions = __('Require and crop double the size set for this image. Enable this if you are using plugins like WP Retina 2x.','acf-image-crop');
 	if($this->getOption('retina_mode')){
-	    $retina_instructions .= '<br>' . __('NB. You currently have enabled retina mode globally for all fields through <a href="' . admin_url('options-media.php') . '#acf-image-crop-retina-mode' . '">settings</a>, which will override this setting.','acf-image_crop');
+	    $retina_instructions .= '<br>' . __('NB. You currently have enabled retina mode globally for all fields through <a href="' . admin_url('options-media.php') . '#acf-image-crop-retina-mode' . '">settings</a>, which will override this setting.','acf-image-crop');
 	}
 ?>
 <tr class="field_option field_option_<?php echo $this->name; ?>">
 	<td class="label">
-		<label><?php _e('Retina/@2x mode ','acf-image_crop'); ?></label>
+		<label><?php _e('Retina/@2x mode ','acf-image-crop'); ?></label>
 		<p><?php echo $retina_instructions ?></p>
 	</td>
 	<td>
@@ -907,7 +907,7 @@ class acf_field_image_crop extends acf_field_image
     function registerSettings(){
         add_settings_section(
             'acf_image_crop_settings',
-            __('ACF Image Crop Settings','acf-image_crop'),
+            __('ACF Image Crop Settings','acf-image-crop'),
             array($this, 'displayImageCropSettingsSection'),
             'media'
         );
@@ -919,7 +919,7 @@ class acf_field_image_crop extends acf_field_image
 
         add_settings_field(
             'acf_image_crop_hide_cropped',      // id
-            __('Hide cropped images from media dialog', 'acf-image_crop'),              // setting title
+            __('Hide cropped images from media dialog', 'acf-image-crop'),              // setting title
             array($this, 'displayHideFromMediaInput'),    // display callback
             'media',                 // settings page
             'acf_image_crop_settings'                  // settings section
@@ -927,7 +927,7 @@ class acf_field_image_crop extends acf_field_image
 
         add_settings_field(
             'acf_image_crop_retina_mode',      // id
-            __('Enable global retina mode (beta)', 'acf-image_crop'),              // setting title
+            __('Enable global retina mode (beta)', 'acf-image-crop'),              // setting title
             array($this, 'displayRetinaModeInput'),    // display callback
             'media',                 // settings page
             'acf_image_crop_settings'                  // settings section

--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -29,7 +29,7 @@ class acf_field_image_crop extends acf_field_image {
         *  label (string) Multiple words, can include spaces, visible when selecting a field type
         */
 
-        $this->label = __('Image with user-crop', 'acf-image_crop');
+        $this->label = __('Image with user-crop', 'acf-image-crop');
 
 
         /*
@@ -73,12 +73,12 @@ class acf_field_image_crop extends acf_field_image {
         */
 
         $this->l10n = array(
-            'width_should_be'   => __( 'Width should be at least: ','acf-image_crop' ),
-            'height_should_be'  => __( 'Height should be at least: ','acf-image_crop' ),
-            'selected_width'    => __( 'Selected image width: ','acf-image_crop' ),
-            'selected_height'   => __( 'Selected image height: ','acf-image_crop' ),
-            'size_warning'      => __( 'Warning: The selected image is smaller than the required size!','acf-image_crop' ),
-            'crop_error'        => __( 'Sorry, an error occurred when trying to crop your image:')
+            'width_should_be'   => __( 'Width should be at least: ','acf-image-crop' ),
+            'height_should_be'  => __( 'Height should be at least: ','acf-image-crop' ),
+            'selected_width'    => __( 'Selected image width: ','acf-image-crop' ),
+            'selected_height'   => __( 'Selected image height: ','acf-image-crop' ),
+            'size_warning'      => __( 'Warning: The selected image is smaller than the required size!','acf-image-crop' ),
+            'crop_error'        => __( 'Sorry, an error occurred when trying to crop your image:','acf-image-crop')
         );
     }
 
@@ -124,29 +124,29 @@ class acf_field_image_crop extends acf_field_image {
 
          // crop_type
         acf_render_field_setting( $field, array(
-            'label'         => __('Crop type','acf-image_crop'),
-            'instructions'  => __('Select the type of crop the user should perform','acf-image_crop'),
+            'label'         => __('Crop type','acf-image-crop'),
+            'instructions'  => __('Select the type of crop the user should perform','acf-image-crop'),
             'type'          => 'select',
             'name'          => 'crop_type',
             'layout'        => 'horizontal',
             'class'         => 'crop-type-select',
             'choices'       => array(
-                'hard'          => __('Hard crop', 'acf-image_crop'),
-                'min'           => __('Minimal dimensions', 'acf-image_crop')
+                'hard'          => __('Hard crop', 'acf-image-crop'),
+                'min'           => __('Minimal dimensions', 'acf-image-crop')
             )
         ));
 
         // target_size
         $sizes = acf_get_image_sizes();
 // added
-        $instructions = __('Select the target size for this field','acf-image_crop');
+        $instructions = __('Select the target size for this field','acf-image-crop');
         if ( $this->getOption('retina_mode') ) {
-            $instructions .= '<br><br><em><strong>'.__('Retina mode is enabled - user will be required to select an image twice this size','acf-image_crop').'</strong></em>';
+            $instructions .= '<br><br><em><strong>'.__('Retina mode is enabled - user will be required to select an image twice this size','acf-image-crop').'</strong></em>';
         }
 // added END
-        $sizes['custom'] = __('Custom size', 'acf-image_crop');
+        $sizes['custom'] = __('Custom size', 'acf-image-crop');
         acf_render_field_setting( $field, array(
-            'label'         => __('Target size','acf-image_crop'),
+            'label'         => __('Target size','acf-image-crop'),
             'instructions'  => $instructions,
             'type'          => 'select',
             'name'          => 'target_size',
@@ -156,8 +156,8 @@ class acf_field_image_crop extends acf_field_image {
 
         // width - conditional: target_size == 'custom'
         acf_render_field_setting( $field, array(
-            'label'         => __('Custom target width','acf-image_crop'),
-            'instructions'  => __('Leave blank for no restriction (does not work with hard crop option)','acf-image_crop'),
+            'label'         => __('Custom target width','acf-image-crop'),
+            'instructions'  => __('Leave blank for no restriction (does not work with hard crop option)','acf-image-crop'),
             'type'          => 'number',
             'name'          => 'width',
             'class'         => 'custom-target-width custom-target-dimension',
@@ -166,8 +166,8 @@ class acf_field_image_crop extends acf_field_image {
 
         // height - conditional: target_size == 'custom'
         acf_render_field_setting( $field, array(
-            'label'         => __('Custom target height','acf-image_crop'),
-            'instructions'  => __('Leave blank for no restriction (does not work with hard crop option)','acf-image_crop'),
+            'label'         => __('Custom target height','acf-image-crop'),
+            'instructions'  => __('Leave blank for no restriction (does not work with hard crop option)','acf-image-crop'),
             'type'          => 'number',
             'name'          => 'height',
             'class'         => 'custom-target-height custom-target-dimension',
@@ -185,8 +185,8 @@ class acf_field_image_crop extends acf_field_image {
 
         // force_crop
         acf_render_field_setting( $field, array(
-            'label'         => __('Force crop','acf-image_crop'),
-            'instructions'  => __('Force the user to crop the image as soon at it is selected','acf-image_crop'),
+            'label'         => __('Force crop','acf-image-crop'),
+            'instructions'  => __('Force the user to crop the image as soon at it is selected','acf-image-crop'),
             'type'          => 'radio',
             'layout'        => 'horizontal',
             'name'          => 'force_crop',
@@ -195,8 +195,8 @@ class acf_field_image_crop extends acf_field_image {
 
         // save_in_media_library
         acf_render_field_setting( $field, array(
-            'label'         => __('Save cropped image to media library','acf-image_crop'),
-            'instructions'  => __('If the cropped image is not saved in the media library, "Image URL" is the only available return value.','acf-image_crop'),
+            'label'         => __('Save cropped image to media library','acf-image-crop'),
+            'instructions'  => __('If the cropped image is not saved in the media library, "Image URL" is the only available return value.','acf-image-crop'),
             'type'          => 'radio',
             'layout'        => 'horizontal',
             'name'          => 'save_in_media_library',
@@ -208,8 +208,8 @@ class acf_field_image_crop extends acf_field_image {
         // retina mode
         if ( !$this->getOption('retina_mode') ) {
             acf_render_field_setting( $field, array(
-                'label'         => __('Retina/@2x mode ','acf-image_crop'),
-                'instructions'  => __('Require and crop double the size set for this image. Enable this if you are using plugins like WP Retina 2x.','acf-image_crop'),
+                'label'         => __('Retina/@2x mode ','acf-image-crop'),
+                'instructions'  => __('Require and crop double the size set for this image. Enable this if you are using plugins like WP Retina 2x.','acf-image-crop'),
                 'type'          => 'radio',
                 'layout'        => 'horizontal',
                 'name'          => 'retina_mode',
@@ -350,20 +350,20 @@ class acf_field_image_crop extends acf_field_image {
         <div class="crop-section">
             <div class="crop-stage">
                 <div class="crop-action">
-                    <h4><?php _e('Crop the image','acf-image_crop'); ?></h4>
+                    <h4><?php _e('Crop the image','acf-image-crop'); ?></h4>
                 <?php if ($imageData->original_image ): ?>
                     <img class="crop-image" src="<?php echo $imageData->original_image_url ?>" data-width="<?php echo $imageData->original_image_width ?>" data-height="<?php echo $imageData->original_image_height ?>" alt="">
                 <?php endif ?>
                 </div>
                 <div class="crop-preview">
-                    <h4><?php _e('Preview','acf-image_crop'); ?></h4>
+                    <h4><?php _e('Preview','acf-image-crop'); ?></h4>
                     <div class="preview"></div>
                     <div class="crop-controls">
-                        <a href="#" class="button button-large cancel-crop-button"><?php _e('Cancel','acf-image_crop'); ?></a> <a href="#" class="button button-large button-primary perform-crop-button"><?php _e('Crop!','acf-image_crop'); ?></a>
+                        <a href="#" class="button button-large cancel-crop-button"><?php _e('Cancel','acf-image-crop'); ?></a> <a href="#" class="button button-large button-primary perform-crop-button"><?php _e('Crop!','acf-image-crop'); ?></a>
                     </div>
                 </div>
             </div>
-            <a href="#" class="button button-large init-crop-button"><?php _e('Crop','acf-image_crop'); ?></a>
+            <a href="#" class="button button-large init-crop-button"><?php _e('Crop','acf-image-crop'); ?></a>
         </div>
     </div>
     <div class="view hide-if-value">
@@ -668,7 +668,7 @@ class acf_field_image_crop extends acf_field_image {
     function registerSettings(){
         add_settings_section(
             'acf_image_crop_settings',
-            __('ACF Image Crop Settings','acf-image_crop'),
+            __('ACF Image Crop Settings','acf-image-crop'),
             array($this, 'displayImageCropSettingsSection'),
             'media'
         );
@@ -686,7 +686,7 @@ class acf_field_image_crop extends acf_field_image {
 
         add_settings_field(
             'acf_image_crop_hide_cropped',      // id
-            __('Hide cropped images from media dialog', 'acf-image_crop'),              // setting title
+            __('Hide cropped images from media dialog', 'acf-image-crop'),              // setting title
             array($this, 'displayHideFromMediaInput'),    // display callback
             'media',                 // settings page
             'acf_image_crop_settings'                  // settings section
@@ -694,7 +694,7 @@ class acf_field_image_crop extends acf_field_image {
 
         add_settings_field(
             'acf_image_crop_retina_mode',      // id
-            __('Enable global retina mode (beta)', 'acf-image_crop'),              // setting title
+            __('Enable global retina mode (beta)', 'acf-image-crop'),              // setting title
             array($this, 'displayRetinaModeInput'),    // display callback
             'media',                 // settings page
             'acf_image_crop_settings'                  // settings section

--- a/acf-image-crop.php
+++ b/acf-image-crop.php
@@ -8,6 +8,8 @@ Author: Anders Thorborg
 Author URI: http://thorb.org
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: acf-image-crop
+Domain Path: /lang
 */
 
 

--- a/acf-image-crop.php
+++ b/acf-image-crop.php
@@ -15,7 +15,7 @@ Domain Path: /lang
 
 // 1. set text domain
 // Reference: https://codex.wordpress.org/Function_Reference/load_plugin_textdomain
-load_plugin_textdomain( 'acf-image_crop', false, dirname( plugin_basename(__FILE__) ) . '/lang/' );
+load_plugin_textdomain( 'acf-image-crop', false, dirname( plugin_basename(__FILE__) ) . '/lang/' );
 
 
 
@@ -46,7 +46,7 @@ add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), 'acf_image_crop_
 
 function acf_image_crop_action_links( $links ) {
 // changed
-   $links[] = '<a href="'. get_admin_url(null, 'options-media.php') .'">'.__('Settings','acf-image_crop').'</a>';
+   $links[] = '<a href="'. get_admin_url(null, 'options-media.php') .'">'.__('Settings','acf-image-crop').'</a>';
 // changed END
    return $links;
 }


### PR DESCRIPTION
- Add Text Domain and Domain Path to plugin header
- Change textdomain strings to match the plugin directory name and conform with the wordpress.org rule that 'The text domain name must use dashes and not underscores'

https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains

Closes #50 