### PR TITLE
Add support for aspect ratio crop

### DIFF
--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -132,7 +132,8 @@ class acf_field_image_crop extends acf_field_image {
             'class'         => 'crop-type-select',
             'choices'       => array(
                 'hard'          => __('Hard crop', 'acf-image_crop'),
-                'min'           => __('Minimal dimensions', 'acf-image_crop')
+                'min'           => __('Minimal dimensions', 'acf-image_crop'),
+                'aspect'          => __('Aspect ratio', 'acf-image_crop'),
             )
         ));
 
@@ -172,6 +173,26 @@ class acf_field_image_crop extends acf_field_image {
             'name'          => 'height',
             'class'         => 'custom-target-height custom-target-dimension',
             'append'        => 'px'
+        ));
+
+        // aspect width - conditional: crop_type == 'aspect'
+        acf_render_field_setting( $field, array(
+            'label'         => __('Aspect ratio width','acf-image_crop'),
+            'instructions'  => __('For example if you want the aspect ratio to be 16:9, enter 16 here.','acf-image_crop'),
+            'type'          => 'number',
+            'name'          => 'aspect_width',
+            'class'         => 'aspect-width aspect-dimension',
+            'append'        => ''
+        ));
+
+        // aspect height - conditional: crop_type == 'aspect'
+        acf_render_field_setting( $field, array(
+            'label'         => __('Aspect ratio height','acf-image_crop'),
+            'instructions'  => __('For example if you want the aspect ratio to be 16:9, enter 9 here.','acf-image_crop'),
+            'type'          => 'number',
+            'name'          => 'aspect_height',
+            'class'         => 'aspect-height aspect-dimension',
+            'append'        => ''
         ));
 
         // preview_size
@@ -288,6 +309,10 @@ class acf_field_image_crop extends acf_field_image {
             $width = $field['width'];
             $height = $field['height'];
         }
+        else if($field['crop_type'] == 'aspect'){
+            $width = 0;
+            $height = 0;
+        }
         else{
             global $_wp_additional_image_sizes;
             $s = $field['target_size'];
@@ -306,6 +331,14 @@ class acf_field_image_crop extends acf_field_image {
             $height = $height * 2;
         }
 
+        $aspect_width = 0;
+        $aspect_height = 0;
+        
+        if($field['crop_type'] == 'aspect'){
+            $aspect_width = $field['aspect_width'];
+            $aspect_height = $field['aspect_height'];
+        }
+
         // vars
         $div_atts = array(
             'class'                 => 'acf-image-uploader acf-cf acf-image-crop',
@@ -314,6 +347,8 @@ class acf_field_image_crop extends acf_field_image {
             'data-target_size'      => $field['target_size'],
             'data-width'            => $width,
             'data-height'           => $height,
+            'data-aspect_width'     => $aspect_width,
+            'data-aspect_height'    => $aspect_height,
             'data-force_crop'       => $field['force_crop'] == 'yes' ? 'true' : 'false',
             'data-save_to_media_library' => $field['save_in_media_library'],
             'data-save_format'      => $field['save_format'],

--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -133,7 +133,7 @@ class acf_field_image_crop extends acf_field_image {
             'choices'       => array(
                 'hard'          => __('Hard crop', 'acf-image_crop'),
                 'min'           => __('Minimal dimensions', 'acf-image_crop'),
-                'aspect'          => __('Aspect ratio', 'acf-image_crop'),
+                'aspect'          => __('Aspect ratio', 'acf-image_crop')
             )
         ));
 

--- a/js/input.js
+++ b/js/input.js
@@ -348,17 +348,8 @@ function initialize_field( $el ) {
         else if($options.data('crop_type') == 'aspect'){
           options.aspectRatio = $options.data('aspect_width') + ':' + $options.data('aspect_height');
 
-          console.log('$options.data(\'aspect_width\')', $options.data('aspect_width'));
-          console.log('$options.data(\'aspect_height\')', $options.data('aspect_height'));
-
           var scaleHeight = options.imageHeight /  $options.data('aspect_height');
           var scaleWidth = options.imageWidth / $options.data('aspect_width');
-
-          console.log('scaleHeight', scaleHeight);
-          console.log('scaleWidth', scaleWidth);
-
-          console.log('options.imageWidth', options.imageWidth);
-          console.log('options.imageHeight', options.imageHeight);
 
           var scale = Math.min(scaleHeight, scaleWidth);
 

--- a/js/input.js
+++ b/js/input.js
@@ -345,6 +345,31 @@ function initialize_field( $el ) {
                 options.y2 = options.imageHeight;
             }
         }
+        else if($options.data('crop_type') == 'aspect'){
+          options.aspectRatio = $options.data('aspect_width') + ':' + $options.data('aspect_height');
+
+          console.log('$options.data(\'aspect_width\')', $options.data('aspect_width'));
+          console.log('$options.data(\'aspect_height\')', $options.data('aspect_height'));
+
+          var scaleHeight = options.imageHeight /  $options.data('aspect_height');
+          var scaleWidth = options.imageWidth / $options.data('aspect_width');
+
+          console.log('scaleHeight', scaleHeight);
+          console.log('scaleWidth', scaleWidth);
+
+          console.log('options.imageWidth', options.imageWidth);
+          console.log('options.imageHeight', options.imageHeight);
+
+          var scale = Math.min(scaleHeight, scaleWidth);
+
+          options.minWidth = 0;
+          options.minHeight = 0;
+          options.x1 = 0;
+          options.y1 = 0;
+          options.x2 = Math.floor($options.data('aspect_width') * scale);
+          options.y2 = Math.floor($options.data('aspect_height') * scale);
+        }
+
         // Center crop - disabled needs more testing
         // options.x1 = options.imageWidth/2 - (options.minWidth/2);
         // options.y1 = options.imageHeight/2 - (options.minHeight/2)

--- a/js/input.js
+++ b/js/input.js
@@ -355,10 +355,19 @@ function initialize_field( $el ) {
 
           options.minWidth = 0;
           options.minHeight = 0;
-          options.x1 = 0;
-          options.y1 = 0;
-          options.x2 = Math.floor($options.data('aspect_width') * scale);
-          options.y2 = Math.floor($options.data('aspect_height') * scale);
+
+          var scaledHeight = Math.floor($options.data('aspect_height') * scale);
+          var scaledWidth = Math.floor($options.data('aspect_width') * scale);
+
+          var y1 = Math.floor((options.imageHeight - scaledHeight) / 2);
+          var x1 = Math.floor((options.imageWidth - scaledWidth) / 2);
+
+          options.x1 = x1;
+          options.y1 = y1;
+
+          options.x2 = scaledWidth + x1;
+          options.y2 = scaledHeight + y1;
+
         }
 
         // Center crop - disabled needs more testing

--- a/js/options.js
+++ b/js/options.js
@@ -7,6 +7,9 @@ jQuery(function($){
 			//console.log(this);
 			toggleSaveFormats(this);
 		});
+    $('.acf-field-object-image-crop .crop-type-select').each(function() {
+      toggleCropType(this);
+    });
 	});
 
 	$(document).on('change', '.acf-field-object-image-crop .target-size-select', function(e) {
@@ -69,6 +72,32 @@ jQuery(function($){
 	});
 	$('.acf-field-object-image-crop .save-in-media-library-select input').each(function() {
 		toggleSaveFormats(this);
+	});
+  $('.acf-field-object-image-crop .crop-type-select').each(function() {
+    toggleCropType(this);
+  });
+
+  function toggleCropType(cropTypeSelect){
+    if($(cropTypeSelect).val() == 'aspect'){
+      $(cropTypeSelect).parents('.acf-field-object-image-crop').first().find('.aspect-dimension').each(function(){
+        $(this).parents('tr.acf-field').first().removeClass('hidden');
+      });
+      $(cropTypeSelect).parents('.acf-field-object-image-crop').first().find('.target-size-select').each(function(){
+        $(this).parents('tr.acf-field').first().addClass('hidden');
+      });
+    }
+    else{
+      $(cropTypeSelect).parents('.acf-field-object-image-crop').first().find('.aspect-dimension').each(function(){
+        $(this).parents('tr.acf-field').first().addClass('hidden');
+      });
+      $(cropTypeSelect).parents('.acf-field-object-image-crop').first().find('.target-size-select').each(function(){
+        $(this).parents('tr.acf-field').first().removeClass('hidden');
+      });
+    }
+	}
+
+  $(document).on('change', '.acf-field-object-image-crop .crop-type-select', function(e) {
+    toggleCropType(this);
 	});
 
 });


### PR DESCRIPTION
I added support for aspect ratio crop that has been useful in my use cases.

It's similar to minimum dimensions but instead of a specific pixel number like 1280x720, you can enter an aspect ratio like 16:9. This is useful in srcset / responsive image implementations where you care more about the aspect ratio than the exact pixel count of the image.

Do you think this would be a good addition the project?

If you don't think it will be appropriate in the scope of the project, I'll be happy to create my own fork instead.

Thanks.