### PR TITLE
Applied max width on image previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Contributors: andersthorborg
 Tags: afc, advanced custom fields, image crop, image, crop
 Requires at least: 3.5
-Tested up to: 4.6
+Tested up to: 4.9.4
 Stable tag: 1.4.12
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -60,6 +60,10 @@ function my_register_fields()
 
 
 ## Changelog ##
+
+### 1.4.13 ###
+* Fix - applied max width on image previews
+* Tested compatibility up to 4.9.4
 
 ### 1.4.12 ###
 * Fix compatibility with ACF Pro 5.6.0

--- a/css/input.css
+++ b/css/input.css
@@ -35,6 +35,11 @@
 .acf-image-crop .crop-section .crop-stage, .acf-image-crop.cropping .image-section, .acf-image-crop.cropping .init-crop-button{
 	display:none;
 }
+
+.acf-image-crop img {
+	max-width: 100%;
+}
+
 .acf-image-crop.cropping .crop-stage {
 	display:block;
 	position:fixed;


### PR DESCRIPTION
Tested and working on WordPress 4.9.4

When cropping large images, they break out of the div in which they are in. I have set a max width on the image preview to provide a fix for this.