### PR TITLE
Broken Access Control Security Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Advanced Custom Fields: Image Crop Add-on #
-Contributors: andersthorborg
+Contributors: andersthorborg, nickkeenan
 Tags: afc, advanced custom fields, image crop, image, crop
 Requires at least: 3.5
-Tested up to: 4.6
-Stable tag: 1.4.12
+Tested up to: 6.9.1
+Stable tag: 1.4.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 An image field making it possible/required for the user to crop the selected image to the specified image size or dimensions
+
+This is a maintained fork of the abandoned [original plugin](https://github.com/andersthorborg/ACF-Image-Crop) by Anders Thorborg.
 
 ## Description ##
 
@@ -58,8 +60,18 @@ function my_register_fields()
 5. The image is cropped to the desired format, using the restrictions set under field options
 6. The new format is shown using the specified preview size. The original image is kept with the field, so the image can be re-cropped at any time.
 
+## Credits ##
+
+Originally developed by [Anders Thorborg](http://thorb.org). 
+This fork maintained by [Nick Keenan / Gameflow Interactive](https://gameflowinteractive.com) 
+with security patches applied. All credit for the original plugin goes to Anders.
 
 ## Changelog ##
+
+### 1.4.13 ###
+**Security fix applied:** CVE-2023-22676 / PSID ae467650d1f0  
+Adds `upload_files` capability check to `perform_crop()` to prevent 
+subscriber-level users from modifying media library images.
 
 ### 1.4.12 ###
 * Fix compatibility with ACF Pro 5.6.0

--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -494,7 +494,11 @@ class acf_field_image_crop extends acf_field_image {
 
     }
 
-    function perform_crop(){
+    function perform_crop
+        if ( ! current_user_can( 'upload_files' ) ) {
+            wp_send_json_error( 'Unauthorized', 403 );
+            wp_die();
+        }
         $targetWidth = $_POST['target_width'];
         $targetHeight = $_POST['target_height'];
 

--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -495,6 +495,10 @@ class acf_field_image_crop extends acf_field_image {
     }
 
     function perform_crop(){
+        if ( ! current_user_can( 'upload_files' ) ) {
+            wp_send_json_error( 'Unauthorized', 403 );
+            wp_die();
+        }
         $targetWidth = $_POST['target_width'];
         $targetHeight = $_POST['target_height'];
 

--- a/acf-image-crop-v5.php
+++ b/acf-image-crop-v5.php
@@ -2,7 +2,7 @@
 
 class acf_field_image_crop extends acf_field_image {
 
-
+    var $options;
     /*
     *  initialize
     *

--- a/acf-image-crop.php
+++ b/acf-image-crop.php
@@ -1,10 +1,10 @@
 <?php
 /*
-Plugin Name: Advanced Custom Fields: Image Crop Add-on
-Plugin URI: https://github.com/andersthorborg/ACF-Image-Crop
-Description: An image field making it possible/required for the user to crop the selected image to the specified image size or dimensions
-Version: 1.4.12
-Author: Anders Thorborg
+Plugin Name: Advanced Custom Fields: Image Crop Add-on (Patched)
+Plugin URI: https://github.com/nickkeenan/ACF-Image-Crop-Patched
+Description: Maintained fork with security fixes. Original by Anders Thorborg.
+Version: 1.4.13
+Author: Anders Thorborg (original), Nick Keenan (maintainer)
 Author URI: http://thorb.org
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Addresses CVE-2023-22676 (Broken Access Control, CVSS 3.1) Security issue
- Adds user capability check to `perform_crop` AJAX action to prevent unauthorized users from cropping media library images
- Original report: https://patchstack.com/database/wordpress/plugin/acf-image-crop-add-on/vulnerability/wordpress-advanced-custom-fields-image-crop-add-on-plugin-1-4-12-broken-access-control
- Addresses a compatibility issue with PHP 8.0+

If this plugin is no longer maintained, I'm happy to create a maintained repository moving forward as this plugin is so helpful for my users.   I have forked to https://github.com/nickkeenan/ACF-Image-Crop-Patched with bumped version numbers for anyone who needs a maintenance fix for this plugin.